### PR TITLE
Fix pointer error

### DIFF
--- a/ps4-wake.c
+++ b/ps4-wake.c
@@ -83,7 +83,7 @@ static int ddp_parse(char *buffer, struct ddp_reply *reply)
             token[2] == 'T' && token[3] == 'P') {
             for (p = token + 8; *p == ' '; p++);
             for (c = p; isdigit(*p); p++);
-            p = '\0'; reply->code = (short)atoi(c);
+            *p = '\0'; reply->code = (short)atoi(c);
             continue;
         }
 


### PR DESCRIPTION
This fixes the following warning:
```
warning: expression which evaluates to zero treated as a null pointer constant of type
      'char *' [-Wnon-literal-null-conversion]
            p = '\0'; reply->code = (short)atoi(c);
                ^~~~
1 warning generated.
```